### PR TITLE
Implementation of symmetric quadratic closure approaches by Tobias Karl

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
 # Pre-commit itself
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -12,12 +12,12 @@ repos:
     -   id: check-toml
 # Black code style formatter
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 24.4.2
     hooks:
       - id: black
 # isort import sorting
 -   repo: https://github.com/timothycrosley/isort
-    rev: '5.10.1'
+    rev: '5.13.2'
     hooks:
       - id: isort
         additional_dependencies: ["toml"]

--- a/fiberoripy/closures.py
+++ b/fiberoripy/closures.py
@@ -28,6 +28,7 @@ def compute_closure(a, closure="IBOF"):
         "ORW",
         "ORW3",
         "SIQ",
+        "SQC",
     )
     if closure == "IBOF":
         return IBOF_closure(a)
@@ -45,6 +46,8 @@ def compute_closure(a, closure="IBOF"):
         return orthotropic_fitted_closures(a, "ORW3")
     if closure == "SIQ":
         return symmetric_implicit_closure(a)
+    if closure == "SQC":
+        return symmetric_quadratic_closure(a)
 
 
 def assert_fot_properties(a):
@@ -752,3 +755,42 @@ def symmetric_implicit_closure(a):
             + np.einsum("...il, ...kj -> ...ijkl", b, b)
         )
     )
+
+
+def symmetric_quadratic_closure(a):
+    """Generate a symmetric quadratic closure.
+    Parameters
+    ----------
+    a : (Mx)3x3 numpy array
+        (Array of) Second order fiber orientation tensor.
+    Returns
+    -------
+    A : (Mx)3x3x3x3 numpy array
+        (Array of) Fourth order fiber orientation tensor.
+    References
+    ----------
+    .. [1] Karl, Tobias and Gatti, Davide and Frohnapfel, Bettina and Böhlke, Thomas,
+       'Asymptotic fiber orientation states of the quadratically
+       closed Folgar--Tucker equation and a subsequent closure
+       improvement',
+       Journal of Rheology 65(5) : 999-1022,
+       https://doi.org/10.1122/8.0000245
+    Notes
+    ----------
+        In general, the SQC does contract to its second-order input.
+    """
+    assert_fot_properties(a)
+
+    a4 = (
+        1.0
+        / 3.0
+        * (
+            np.einsum("...ij, ...kl -> ...ijkl", a, a)
+            + np.einsum("...ik, ...lj -> ...ijkl", a, a)
+            + np.einsum("...il, ...kj -> ...ijkl", a, a)
+        )
+    )
+
+    a4 /= 1.0 / 3.0 * (1.0 + 2.0 * np.einsum("...ij, ...ij -> ...", a, a))
+
+    return a4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fiberoripy"
-version = "1.1.3"
+version = "1.1.4"
 description = "Fiber orientation models and closures"
 authors = [{name="Nils Meyer", email = "nils.meyer@uni-a.de"}, {name="Constantin Krauß"}, {name="Louis Schreyer"}, {name="Julian Karl Bauer"}]
 license = {file = "LICENSE"}

--- a/tests/test_closure.py
+++ b/tests/test_closure.py
@@ -26,8 +26,8 @@ def get_test_tensors():
 @pytest.mark.parametrize("a", get_test_tensors())
 @pytest.mark.parametrize(
     "type",
-    ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "ORF"]
-    # "type", ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "RANDOM"]
+    ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "ORF", "SIQ"],
+    # "type", ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "RANDOM", ]
 )
 def test_reduction(a, type):
     """Test contraction property."""
@@ -41,7 +41,7 @@ def test_reduction(a, type):
 @pytest.mark.parametrize("a", get_test_tensors())
 @pytest.mark.parametrize(
     "type",
-    ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "ORF"]
+    ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "ORF", "SIQ"],
     # "type", ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "RANDOM"]
 )
 def test_contraction(a, type):

--- a/tests/test_closure.py
+++ b/tests/test_closure.py
@@ -41,7 +41,7 @@ def test_reduction(a, type):
 @pytest.mark.parametrize("a", get_test_tensors())
 @pytest.mark.parametrize(
     "type",
-    ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "ORF", "SIQ"],
+    ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "ORF", "SIQ", "SQC"],
     # "type", ["IBOF", "LINEAR", "HYBRID", "QUADRATIC", "RANDOM"]
 )
 def test_contraction(a, type):


### PR DESCRIPTION
added the explicit (SQC: violates algebraic contraction requirement) and the implicit (SIC: yields admissible FOT in any case) symmetric quadratic closure schemes as proposed by Karl et al. 

Note: SIC is not broadcastable atm since it requires numerical root determination for each input and scipy's `root_scalar` method is not broadcastable. Might put a loop in the function scope later for the sake of consistency, but this won't speed up computation. 